### PR TITLE
Upgrade Quorum to v2.1.1

### DIFF
--- a/qm.variables
+++ b/qm.variables
@@ -1,3 +1,3 @@
 dockerImage=syneblock/quorum-maker
-quorum_version=v2.1.0    # Quorum Branch or Tag
+quorum_version=v2.1.1    # Quorum Branch or Tag
 quorum_maker_version=2.5 # Not the branch or Tag, rather the default tag for the image. Branch or Tag will be from currently checkout git source.


### PR DESCRIPTION
Hi,

Please upgrade Quorum to v2.1.1.

v2.1.1 fixes a major bug: [#517 Fix consensus on private contract failure](https://github.com/jpmorganchase/quorum/pull/517)

This bug causes a bad block every time a private transaction is reverted and makes local development difficult.

Thank you!

